### PR TITLE
Correct URL Seperator

### DIFF
--- a/build/app/code/community/Symmetrics/TrustedRating/Block/RateUs/Abstract.php
+++ b/build/app/code/community/Symmetrics/TrustedRating/Block/RateUs/Abstract.php
@@ -159,7 +159,7 @@ abstract class Symmetrics_TrustedRating_Block_RateUs_Abstract extends Mage_Core_
                 $baseUrl = preg_replace('/^https?:/', '', $baseUrl);
             }
             $baseUrl .= Symmetrics_TrustedRating_Model_Trustedrating::RATEUS_BUTTON_IMAGE_SUBPATH;
-            $baseUrl .= DS;
+            $baseUrl .= '/';
             
             $this->setData($dataKey, $baseUrl);
         }


### PR DESCRIPTION
DS on a Windows Machine is "\" which fails in some Browsers => ``http://shop.de/media/trustedrating/buttons\$.png``.

'/' is more appropriate here.